### PR TITLE
Option passing

### DIFF
--- a/puglatizer.js
+++ b/puglatizer.js
@@ -47,8 +47,8 @@ module.exports = function(templateDirectories,outputFile,opts,done) {
 			fs.stat(outputFile,function(err,stat) {
 				if (err) { return callback(null) }
 				console.log('Found old ' + outputFile + ' so now removing')
-				fs.unlink(outputFile)
-				return callback(null)
+				fs.unlinkSync(outputFile)
+        return callback(null)
 			})
 		},
 		// Create the initial file

--- a/puglatizer.js
+++ b/puglatizer.js
@@ -10,13 +10,14 @@ var pug = require('pug'),
 	minify = require('harp-minify'),
 	filePaths = []
 
-var buildTemplateFromFile = function(filepath,respond) {
+var buildTemplateFromFile = function(filepath,options,respond) {
 	fs.stat(filepath,function(err,stat) {
 		if (err) { return respond(err) }
 		fs.readFile(filepath,function(err,fileData) {
 			if (err) { return respond(err) }
 			try {
-				var compiledPug = pug.compile(fileData)
+        options.filename = filepath
+				var compiledPug = pug.compile(fileData, options)
 				var template = wrap(compiledPug)
 				return respond(null,template)
 			} catch(err) {
@@ -35,6 +36,10 @@ module.exports = function(templateDirectories,outputFile,opts,done) {
 
 	var options =  opts && typeof opts == 'object' ? opts : {},
 		results = {}
+
+  if(!options.hasOwnProperty('basedir')){
+    options.basedir = templateDirectories
+  }
 
 	async.waterfall([
 		// Unbuild old template file if exists
@@ -126,7 +131,7 @@ module.exports = function(templateDirectories,outputFile,opts,done) {
 								if (ext == '.pug') {
 									var pugatizerPath = '    puglatizer' + currentDir.replace(templateDirectories,'').replace(/\//g,'"]["') + '"]["' + file.replace('.pug','') + '"] = '
 									pugatizerPath = pugatizerPath.replace('puglatizer"]','puglatizer')
-									buildTemplateFromFile(filepath,function(err,template) {
+									buildTemplateFromFile(filepath,options,function(err,template) {
 										pugatizerPath += minify.js(template.toString()) + ';\r\n\r\n'
 										fs.appendFileSync(outputFile,pugatizerPath)
 										finishFile(i)


### PR DESCRIPTION
Would love to have the ability to pass the option object to the compile.pug call.
Though include and extend inside the templates requires at least the filename option
to be set.  The filename option will be just taken from the current templates filepath..